### PR TITLE
Update depreciated function

### DIFF
--- a/nytimes_scraper/articles/postprocessing.py
+++ b/nytimes_scraper/articles/postprocessing.py
@@ -1,11 +1,10 @@
 from typing import List, Dict
 
 import pandas as pd
-import pandas.io.json
 
 
 def articles_to_df(articles: List[Dict]) -> pd.DataFrame:
-    df = pd.io.json.json_normalize(articles).set_index('_id')
+    df = pd.json_normalize(articles).set_index('_id')
 
     if 'pub_date' in df:
         df['pub_date'] = pd.to_datetime(df['pub_date'])

--- a/nytimes_scraper/comments/postprocessing.py
+++ b/nytimes_scraper/comments/postprocessing.py
@@ -1,14 +1,13 @@
 from typing import List, Dict
 
 import pandas as pd
-import pandas.io.json
 
 from nytimes_scraper.comments.util import flatten_replies, remove_reply_references
 
 
 def comments_to_df(comments: List[Dict]) -> pd.DataFrame:
     all_comments = remove_reply_references(flatten_replies(comments))
-    df = pd.io.json.json_normalize(all_comments).set_index('commentID')
+    df = pd.json_normalize(all_comments).set_index('commentID')
 
     if 'parentID' in df:
         df['parentID'] = df['parentID'].astype(pd.Int64Dtype())


### PR DESCRIPTION
Pandas now contains the json_normalize functions as pandas.io.json is deprecated (FutureWarning raised on pandas version 1.1.3)